### PR TITLE
Update typo in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 model = AutoModelForCausalLM.from_pretrained("databricks/dolly-v2-12b")
 tokenizer = AutoTokenizer.from_pretrained("databricks/dolly-v2-12b")
 
-schema = {
+json_schema = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},


### PR DESCRIPTION
As far as can tell, the variable should be named `json_schema` in the example.