### PR TITLE
Add integer and enum types

### DIFF
--- a/jsonformer/logits_processors.py
+++ b/jsonformer/logits_processors.py
@@ -82,3 +82,54 @@ class OutputNumbersTokens(LogitsWarper):
         scores[~mask] = -float("inf")
 
         return scores
+
+class IntegerStoppingCriteria(StoppingCriteria):
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizer,
+        prompt_length: int,
+        max_digits: int = 15,
+    ):
+        self.tokenizer = tokenizer
+        self.prompt_length = prompt_length
+        self.max_digits = max_digits
+
+    def __call__(
+        self,
+        input_ids: torch.LongTensor,
+        scores: torch.FloatTensor,
+    ) -> bool:
+        decoded = self.tokenizer.decode(
+            input_ids[0][self.prompt_length :], skip_special_tokens=True
+        )
+
+        if len(decoded.strip()) > self.max_digits:
+            return True
+
+        if (
+            len(decoded) > 1
+            and any(c.isdigit() for c in decoded)
+            and decoded[-1] in [" ", "\n"]
+        ):
+            return True
+
+        return False
+
+class OutputIntegersTokens(LogitsWarper):
+    def __init__(self, tokenizer: PreTrainedTokenizer, prompt: str):
+        self.tokenizer = tokenizer
+        self.tokenized_prompt = tokenizer(prompt, return_tensors="pt")
+        vocab_size = len(tokenizer)
+        self.allowed_mask = torch.zeros(vocab_size, dtype=torch.bool)
+
+        for _, token_id in tokenizer.get_vocab().items():
+            token_str = tokenizer.decode(token_id).strip()
+
+            if token_str == "" or all(c.isdigit() for c in token_str):
+                self.allowed_mask[token_id] = True
+
+    def __call__(self, _, scores):
+        mask = self.allowed_mask.expand_as(scores)
+        scores[~mask] = -float("inf")
+
+        return scores

--- a/jsonformer/main.py
+++ b/jsonformer/main.py
@@ -178,12 +178,12 @@ class Jsonformer:
         highest_probability = 0.0
         best_option = None
         for option in enum_values:
-            option_tokens = self.tokenizer.encode(f'"{option}"', return_tensors="pt")
-            n_option_tokens = option_tokens.shape[1]
-            prompt_option_tokens = torch.concat([prompt_tokens, option_tokens], dim=1)
+            n_option_tokens = self.tokenizer.encode(f'"{option}"', add_special_tokens=False, return_tensors="pt").shape[1]
+            prompt_tokens = self.tokenizer.encode(prompt + f'"{option}"', return_tensors="pt")
+            option_tokens = prompt_tokens[0, -n_option_tokens:]
 
             with torch.no_grad():
-                logits = self.model.forward(prompt_option_tokens.to(self.model.device)).logits[0, -n_option_tokens-1:-1]
+                logits = self.model.forward(prompt_tokens[:, :-1].to(self.model.device)).logits[0, -n_option_tokens:]
             probabilities = torch.softmax(logits, dim=1)
             option_token_probabilities = probabilities[torch.arange(probabilities.shape[0]), option_tokens]
             option_probability = torch.prod(option_token_probabilities).item()

--- a/jsonformer/main.py
+++ b/jsonformer/main.py
@@ -181,7 +181,7 @@ class Jsonformer:
         # These are necessary because we don't know if we're at the end or middle of an object/array
         terminal_tokens = torch.concat([
             self.tokenizer.encode(s, add_special_tokens=False, return_tensors="pt")[:, 0]
-            for s in ('", "', '"}', '"]dsdsf')
+            for s in ('", "', '"}', '"]')
         ])
 
         highest_probability = 0.0

--- a/jsonformer/main.py
+++ b/jsonformer/main.py
@@ -76,7 +76,9 @@ class Jsonformer:
         response = self.tokenizer.decode(response[0], skip_special_tokens=True)
 
         response = response[len(prompt) :]
-        response = response.strip().rstrip(".")
+        if "," in response:
+            response = response.split(",")[0]
+        response = response.replace(" ", "").rstrip(".")
         self.debug("[generate_number]", response)
         try:
             return float(response)
@@ -106,7 +108,9 @@ class Jsonformer:
         response = self.tokenizer.decode(response[0], skip_special_tokens=True)
 
         response = response[len(prompt) :]
-        response = response.strip()
+        if "," in response:
+            response = response.split(",")[0]
+        response = response.replace(" ", "")
         self.debug("[generate_integer]", response)
         try:
             return int(response)

--- a/jsonformer/main.py
+++ b/jsonformer/main.py
@@ -124,11 +124,8 @@ class Jsonformer:
         output = self.model.forward(input_tensor.to(self.model.device))
         logits = output.logits[0, -1]
 
-        # todo: this assumes that "true" and "false" are both tokenized to a single token
-        # this is probably not true for all tokenizers
-        # this can be fixed by looking at only the first token of both "true" and "false"
-        true_token_id = self.tokenizer.convert_tokens_to_ids("true")
-        false_token_id = self.tokenizer.convert_tokens_to_ids("false")
+        true_token_id = self.tokenizer.encode("true", return_tensors="pt")[0, 0]
+        false_token_id = self.tokenizer.encode("false", return_tensors="pt")[0, 0]
 
         result = logits[true_token_id] > logits[false_token_id]
 


### PR DESCRIPTION
This PR adds 2 new types and enforces their correct generation:
- Integers: These are treated as json numbers but will never contain a "." character so can be parsed as ints. (Regular numbers will practically always have a "." character currently. Is this intended?)
- Enums: These are treated as json strings but will only ever be one of several options specified in the schema.

Example schema:
```
car = {
    "type": "object",
    "properties": {
        "make": {"type": "string"},
        "model": {"type": "string"},
        "year": {"type": "integer"},
        "color": {
            "type": "enum",
            "values": ["red", "green", "blue", "brown", "white", "black"],
        },
    },
}
```

I also went ahead and fixed the issue described in the todo in the generate bool method since it was an easy fix.

BTW, the performance is much better since I last checked up on this library so great job on that!