### PR TITLE
Add support for null and union types

### DIFF
--- a/jsonformer/main.py
+++ b/jsonformer/main.py
@@ -153,7 +153,7 @@ class Jsonformer:
 
     def choose_type_to_generate(self, possible_types: List[str]) -> str:
         possible_types = list(set(possible_types))  # remove duplicates
-        self.debug("[choosing type to generate]", possible_types)
+        self.debug("[choose_type_to_generate]", possible_types)
         if len(possible_types) < 1:
             raise ValueError(f"Union type must not be empty")
         elif len(possible_types) == 1:
@@ -165,11 +165,11 @@ class Jsonformer:
         logits = output.logits[0, -1]
 
         max_type = None
-        max_logit = -1
+        max_logit = -float("inf")
         for possible_type in possible_types:
             try: 
                 prefix_tokens = self.type_prefix_tokens[possible_type]
-            except IndexError:
+            except KeyError:
                 raise ValueError(f"Unsupported schema type: {possible_type}")
             max_type_logit = logits[prefix_tokens].max()
             if max_type_logit > max_logit:
@@ -178,7 +178,7 @@ class Jsonformer:
 
         if max_type is None:
             raise Exception("Unable to find best type to generate for union type")
-        self.debug("[chose type to generate]", max_type)
+        self.debug("[choose_type_to_generate]", max_type)
         return max_type
     
     def generate_value(

--- a/jsonformer/type_prefixes.py
+++ b/jsonformer/type_prefixes.py
@@ -1,0 +1,32 @@
+from transformers import PreTrainedTokenizer
+from typing import Dict, List
+import re
+
+def is_number_prefix(s: str) -> bool:
+    return re.match(r"^[\-\d]+\.?[\d]*$", s)
+
+def is_boolean_prefix(s: str) -> bool:
+    return 'true'.startswith(s) or 'false'.startswith(s)
+
+def is_null_prefix(s: str) -> bool:
+    return 'null'.startswith(s)
+
+def is_string_prefix(s: str) -> bool:
+    return re.match(r'^"[^"]*"?$', s)
+
+def is_array_prefix(s: str) -> bool:
+    return re.match(r'^\[["\-\d\[{]*$', s)
+
+def is_object_prefix(s: str) -> bool:
+    return re.match(r'^\{"?$', s)
+
+def get_prefix_tokens_for_types(tokenizer: PreTrainedTokenizer) -> Dict[str, List[str]]:
+    vocab = tokenizer.vocab.items()
+    return {
+        "number": [v for k, v in vocab if is_number_prefix(k)],
+        "boolean": [v for k, v in vocab if is_boolean_prefix(k)],
+        "null": [v for k, v in vocab if is_null_prefix(k)],
+        "string": [v for k, v in vocab if is_string_prefix(k)],
+        "array": [v for k, v in vocab if is_array_prefix(k)],
+        "object": [v for k, v in vocab if is_object_prefix(k)],
+    }


### PR DESCRIPTION
resolves #29, resolves #26

Example:

```python
from jsonformer.format import highlight_values
from jsonformer.main import Jsonformer
from transformers import AutoModelForCausalLM, AutoTokenizer
import torch

print("Loading model and tokenizer...")
model_name = "databricks/dolly-v2-3b"
model = AutoModelForCausalLM.from_pretrained(model_name, use_cache=True, device_map="auto", offload_folder='offload', torch_dtype=torch.float32)
tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True, use_cache=True)
print("Loaded model and tokenizer")

car = {
    "type": "object",
    "properties": {
        "make": {"type": "string"},
        "model": {"type": "string"},
        "year": {"type": "number"},
        "trim": {"type": ["string", "null"]},
    },
}

builder = Jsonformer(
    model=model,
    tokenizer=tokenizer,
    json_schema=car,
    debug=True,
    prompt='Make an example car json for Dodge Charger ',
)

print("Generating...")
output = builder()

highlight_values(output)
```

output:
```
{
  make: "Dodge",
  model: "Charger",
  year: 1991.0,
  trim: None
}
```