### PR TITLE
Changed positional arg to keyword arg for compatibility with auto-gptq

### DIFF
--- a/jsonformer/main.py
+++ b/jsonformer/main.py
@@ -59,7 +59,7 @@ class Jsonformer:
             self.model.device
         )
         response = self.model.generate(
-            input_tokens,
+            inputs=input_tokens,
             max_new_tokens=self.max_number_tokens,
             num_return_sequences=1,
             logits_processor=[self.number_logit_processor],
@@ -110,7 +110,7 @@ class Jsonformer:
         )
 
         response = self.model.generate(
-            input_tokens,
+            inputs=input_tokens,
             max_new_tokens=self.max_string_token_length,
             num_return_sequences=1,
             temperature=self.temperature,


### PR DESCRIPTION
This PR addresses an incompatibility with the [auto-gptq](https://github.com/PanQiWei/AutoGPTQ) library:

```python
  File "/home/matt/miniconda3/envs/gptq/lib/python3.11/site-packages/jsonformer/main.py", line 112, in generate_string
    response = self.model.generate(
               ^^^^^^^^^^^^^^^^^^^^
TypeError: BaseGPTQForCausalLM.generate() takes 1 positional argument but 2 were given
```