### PR TITLE
Use LogitsProcessor instead of LogitsWarper

### DIFF
--- a/jsonformer/logits_processors.py
+++ b/jsonformer/logits_processors.py
@@ -1,5 +1,5 @@
 from typing import List
-from transformers import PreTrainedTokenizer, LogitsWarper, StoppingCriteria
+from transformers import PreTrainedTokenizer, LogitsProcessor, StoppingCriteria
 import torch
 
 class StringStoppingCriteria(StoppingCriteria):
@@ -61,7 +61,7 @@ class NumberStoppingCriteria(StoppingCriteria):
 
         return False
 
-class OutputNumbersTokens(LogitsWarper):
+class OutputNumbersTokens(LogitsProcessor):
     def __init__(self, tokenizer: PreTrainedTokenizer, prompt: str):
         self.tokenizer = tokenizer
         self.tokenized_prompt = tokenizer(prompt, return_tensors="pt")


### PR DESCRIPTION
LogitsWarper was removed from HuggingFace. LogitsProcessor is a drop-in replacement. See https://github.com/huggingface/transformers/pull/32626