### PR TITLE
fixed deprecated LogitsWarper bug

### DIFF
--- a/jsonformer/logits_processors.py
+++ b/jsonformer/logits_processors.py
@@ -1,5 +1,4 @@
-from typing import List
-from transformers import PreTrainedTokenizer, LogitsWarper, StoppingCriteria
+from transformers import PreTrainedTokenizer, LogitsProcessor, StoppingCriteria
 import torch
 
 class StringStoppingCriteria(StoppingCriteria):
@@ -61,7 +60,7 @@ class NumberStoppingCriteria(StoppingCriteria):
 
         return False
 
-class OutputNumbersTokens(LogitsWarper):
+class OutputNumbersTokens(LogitsProcessor):
     def __init__(self, tokenizer: PreTrainedTokenizer, prompt: str):
         self.tokenizer = tokenizer
         self.tokenized_prompt = tokenizer(prompt, return_tensors="pt")


### PR DESCRIPTION
When I used Jsonformer I got the following error:

```bash
  File "/root/XXX/venv/lib/python3.11/site-packages/jsonformer/logits_processors.py", l
ine 2, in <module>
    from transformers import PreTrainedTokenizer, LogitsWarper, StoppingCriteria
ImportError: cannot import name 'LogitsWarper' from 'transformers'
```
Basically, the Jsonformer refers to a LogitsWarper, which has no longer been used for recent transformers. I updated the piece and replaced it with an up-to-date LogitsProcessor.